### PR TITLE
Move dispatch after listner subscription

### DIFF
--- a/src/reduxPromiseListener.js
+++ b/src/reduxPromiseListener.js
@@ -45,12 +45,6 @@ export default function createListener(): PromiseListener {
     }
     const asyncFunction = (payload: any) =>
       new Promise((resolve, reject) => {
-        dispatch(
-          (config.setPayload || defaultSetPayload)(
-            { type: config.start },
-            payload
-          )
-        )
         const listener: Listener = action => {
           if (
             action.type === config.resolve ||
@@ -67,6 +61,12 @@ export default function createListener(): PromiseListener {
           }
         }
         listeners[listenerId] = listener
+        dispatch(
+          (config.setPayload || defaultSetPayload)(
+            { type: config.start },
+            payload
+          )
+        )
       })
 
     return { asyncFunction, unsubscribe }


### PR DESCRIPTION
It was possible for resolve/reject action to fire before listener is
subscribed to it if API is mocked without delays. That resulted in
asyncFunction ignoring the action completely.

<!--

👋 Hey, thanks for your interest in contributing to Redux Promise Listener!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a
lot of time and effort into a new feature. To avoid this from happening, we
request that contributors create an issue to first discuss any significant new
features.

Please try to keep your pull request focused in scope and avoid including
unrelated commits.

After you have submitted your pull request, we’ll try to get back to you as soon
as possible. We may suggest some changes or improvements.

Please format the code before submitting your pull request by running:

```
npm run precommit
```

https://github.com/erikras/redux-promise-listener/blob/master/.github/CONTRIBUTING.md

-->
