### PR TITLE
Support functions as a start option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "redux-promise-listener",
-  "version": "1.1.0",
+  "name": "@colony/redux-promise-listener",
+  "version": "1.2.0",
   "description": "A Redux middleware that allows actions to be converted into Promises",
   "main": "dist/redux-promise-listener.cjs.js",
   "jsnext:main": "dist/redux-promise-listener.es.js",
@@ -13,16 +13,19 @@
     "test": "nps test",
     "precommit": "lint-staged && npm start validate"
   },
-  "author": "Erik Rasmussen <rasmussenerik@gmail.com> (http://github.com/erikras)",
+  "contributors": [
+    "Erik Rasmussen <rasmussenerik@gmail.com> (http://github.com/erikras)",
+    "Christian Maniewski <chris@colony.io>"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/erikras/redux-promise-listener.git"
+    "url": "https://github.com/joincolony/redux-promise-listener.git"
   },
   "bugs": {
-    "url": "https://github.com/erikras/redux-promise-listener/issues"
+    "url": "https://github.com/joincolony/redux-promise-listener/issues"
   },
-  "homepage": "https://github.com/erikras/redux-promise-listener#readme",
+  "homepage": "https://github.com/joincolony/redux-promise-listener#readme",
   "devDependencies": {
     "babel-eslint": "^8.2.6",
     "babel-jest": "^23.4.2",

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -2,7 +2,7 @@
 import type { Store, Middleware } from 'redux'
 
 export type State = any
-export type Action = { type: string, payload?: any }
+export type Action = { type: string, payload?: any, meta?: any }
 export type Next = Action => State
 export type SetPayload = (Action, any) => Action
 export type GetPayload = Action => ?any

--- a/src/reduxPromiseListener.js
+++ b/src/reduxPromiseListener.js
@@ -66,12 +66,16 @@ export default function createListener(): PromiseListener {
           }
         }
         listeners[listenerId] = listener
-        dispatch(
-          (config.setPayload || defaultSetPayload)(
+        let action
+        if (typeof config.start === 'function') {
+          action = config.start({ payload, meta: { id } })
+        } else {
+          action = (config.setPayload || defaultSetPayload)(
             { type: config.start, meta: { id } },
             payload
           )
-        )
+        }
+        dispatch(action)
       })
 
     return { asyncFunction, unsubscribe }

--- a/src/reduxPromiseListener.js
+++ b/src/reduxPromiseListener.js
@@ -48,12 +48,6 @@ export default function createListener(): PromiseListener {
         const id = Math.random()
           .toString(36)
           .substr(2)
-        dispatch(
-          (config.setPayload || defaultSetPayload)(
-            { type: config.start, meta: { id } },
-            payload
-          )
-        )
         const listener: Listener = action => {
           // If action has an id, check whether it's correct
           if (action.meta && action.meta.id && action.meta.id !== id) return
@@ -72,6 +66,12 @@ export default function createListener(): PromiseListener {
           }
         }
         listeners[listenerId] = listener
+        dispatch(
+          (config.setPayload || defaultSetPayload)(
+            { type: config.start, meta: { id } },
+            payload
+          )
+        )
       })
 
     return { asyncFunction, unsubscribe }

--- a/src/reduxPromiseListener.js
+++ b/src/reduxPromiseListener.js
@@ -45,13 +45,18 @@ export default function createListener(): PromiseListener {
     }
     const asyncFunction = (payload: any) =>
       new Promise((resolve, reject) => {
+        const id = Math.random()
+          .toString(36)
+          .substr(2)
         dispatch(
           (config.setPayload || defaultSetPayload)(
-            { type: config.start },
+            { type: config.start, meta: { id } },
             payload
           )
         )
         const listener: Listener = action => {
+          // If action has an id, check whether it's correct
+          if (action.meta && action.meta.id && action.meta.id !== id) return
           if (
             action.type === config.resolve ||
             (typeof config.resolve === 'function' && config.resolve(action))

--- a/src/reduxPromiseListener.test.js
+++ b/src/reduxPromiseListener.test.js
@@ -67,7 +67,8 @@ describe('redux-promise-listener', () => {
       expect(reducer).toHaveBeenCalledTimes(2)
       expect(reducer.mock.calls[1][1]).toEqual({
         type: 'START',
-        payload: 'foo'
+        payload: 'foo',
+        meta: { id: expect.any(String) }
       })
 
       await sleep(1)
@@ -120,7 +121,8 @@ describe('redux-promise-listener', () => {
       expect(reducer).toHaveBeenCalledTimes(2)
       expect(reducer.mock.calls[1][1]).toEqual({
         type: 'START',
-        payload: 'foo'
+        payload: 'foo',
+        meta: { id: expect.any(String) }
       })
 
       await sleep(1)
@@ -173,7 +175,8 @@ describe('redux-promise-listener', () => {
       expect(reducer).toHaveBeenCalledTimes(2)
       expect(reducer.mock.calls[1][1]).toEqual({
         type: 'START',
-        payload: 'foo'
+        payload: 'foo',
+        meta: { id: expect.any(String) }
       })
 
       await sleep(1)
@@ -226,7 +229,8 @@ describe('redux-promise-listener', () => {
       expect(reducer).toHaveBeenCalledTimes(2)
       expect(reducer.mock.calls[1][1]).toEqual({
         type: 'START',
-        payload: 'foo'
+        payload: 'foo',
+        meta: { id: expect.any(String) }
       })
 
       await sleep(1)
@@ -247,6 +251,63 @@ describe('redux-promise-listener', () => {
       expect(reject).toHaveBeenCalled()
       expect(reject).toHaveBeenCalledTimes(1)
       expect(reject.mock.calls[0][0]).toBe('bar')
+    })
+
+    it('should not react to an action with a wrong id', async () => {
+      const reducer = jest.fn((state, action) => state)
+      const initialState = {}
+      const { middleware, createAsyncFunction } = createListener()
+      const store = createStore(
+        reducer,
+        initialState,
+        applyMiddleware(middleware)
+      )
+      expect(reducer).toHaveBeenCalledTimes(1)
+
+      const { asyncFunction } = createAsyncFunction({
+        start: 'START',
+        resolve: action => action.type === 'RESOLVE',
+        reject: action => action.type === 'REJECT'
+      })
+
+      // nothing dispatched yet
+      expect(reducer).toHaveBeenCalledTimes(1)
+
+      const resolve = jest.fn()
+      const reject = jest.fn()
+      asyncFunction('foo').then(resolve, reject)
+      expect(resolve).not.toHaveBeenCalled()
+      expect(reject).not.toHaveBeenCalled()
+
+      // start action dispatched
+      expect(reducer).toHaveBeenCalledTimes(2)
+      expect(reducer.mock.calls[1][1]).toEqual({
+        type: 'START',
+        payload: 'foo',
+        meta: { id: expect.any(String) }
+      })
+
+      expect(resolve).not.toHaveBeenCalled()
+      expect(reject).not.toHaveBeenCalled()
+
+      store.dispatch({
+        type: 'RESOLVE',
+        payload: 'whatever',
+        meta: { id: 'wrongid' }
+      })
+
+      await sleep(1)
+
+      expect(resolve).not.toHaveBeenCalled()
+      expect(reject).not.toHaveBeenCalled()
+
+      const { id } = reducer.mock.calls[1][1].meta
+      store.dispatch({ type: 'RESOLVE', payload: 'whatever', meta: { id } })
+
+      await sleep(1)
+
+      expect(resolve).toHaveBeenCalled()
+      expect(reject).not.toHaveBeenCalled()
     })
 
     it('should not call resolve twice', async () => {
@@ -279,7 +340,8 @@ describe('redux-promise-listener', () => {
       expect(reducer).toHaveBeenCalledTimes(2)
       expect(reducer.mock.calls[1][1]).toEqual({
         type: 'START',
-        payload: 'foo'
+        payload: 'foo',
+        meta: { id: expect.any(String) }
       })
 
       await sleep(1)
@@ -340,7 +402,8 @@ describe('redux-promise-listener', () => {
       expect(reducer).toHaveBeenCalledTimes(2)
       expect(reducer.mock.calls[1][1]).toEqual({
         type: 'START',
-        payload: 'foo'
+        payload: 'foo',
+        meta: { id: expect.any(String) }
       })
 
       await sleep(1)
@@ -403,7 +466,8 @@ describe('redux-promise-listener', () => {
       expect(reducer).toHaveBeenCalledTimes(2)
       expect(reducer.mock.calls[1][1]).toEqual({
         type: 'START',
-        data: 'foo'
+        data: 'foo',
+        meta: { id: expect.any(String) }
       })
 
       await sleep(1)
@@ -458,7 +522,8 @@ describe('redux-promise-listener', () => {
       expect(reducer).toHaveBeenCalledTimes(2)
       expect(reducer.mock.calls[1][1]).toEqual({
         type: 'START',
-        data: 'foo'
+        data: 'foo',
+        meta: { id: expect.any(String) }
       })
 
       await sleep(1)


### PR DESCRIPTION
This PR adds support for passing in a function as the start property allowing for more complex workflows (like using action creators directly in the async function). Note that this will effectively override the `setPayload` property (which we should probably just remove anywhere as it’s not really needed anymore). I’ll leave it in for now with a note of deprecation.